### PR TITLE
Bring back PHP 8.1 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2]
+        php: [8.2, 8.1]
         laravel: [10.*]
         statamic: [^4.0]
         testbench: [8.*]

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.1",
         "statamic/cms": "^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
This pull request brings back support for PHP 8.1 to this addon, which was previously removed in the Statamic 4 update.