### PR TITLE
Adds support for multi-site path configurations

### DIFF
--- a/src/Http/Controllers/ClearController.php
+++ b/src/Http/Controllers/ClearController.php
@@ -21,13 +21,21 @@ class ClearController
 
     protected function delete($path): void
     {
-        $path = config('statamic.static_caching.strategies.full.path').Str::ensureLeft($path, '/');
+        $cachePaths = config('statamic.static_caching.strategies.full.path');
 
-        if (File::isDirectory($path)) {
-            $this->deleteDirectory($path);
+        if (!is_array($cachePaths)) {
+            $cachePaths = [$cachePaths];
         }
 
-        $this->deleteFile($path);
+        foreach ($cachePaths as $cachePath) {
+            $path = $cachePath.Str::ensureLeft($path, '/');
+
+            if (File::isDirectory($path)) {
+                $this->deleteDirectory($path);
+            }
+
+            $this->deleteFile($path);
+        }
     }
 
     protected function deleteFile($path): void

--- a/src/Http/Controllers/ClearController.php
+++ b/src/Http/Controllers/ClearController.php
@@ -23,7 +23,7 @@ class ClearController
     {
         $cachePaths = config('statamic.static_caching.strategies.full.path');
 
-        if (!is_array($cachePaths)) {
+        if (! is_array($cachePaths)) {
             $cachePaths = [$cachePaths];
         }
 

--- a/src/Http/Controllers/ClearController.php
+++ b/src/Http/Controllers/ClearController.php
@@ -3,6 +3,7 @@
 namespace DuncanMcClean\StaticCacheManager\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\File;
 use Statamic\Support\Str;
 
@@ -23,11 +24,7 @@ class ClearController
     {
         $cachePaths = config('statamic.static_caching.strategies.full.path');
 
-        if (! is_array($cachePaths)) {
-            $cachePaths = [$cachePaths];
-        }
-
-        foreach ($cachePaths as $cachePath) {
+        collect(Arr::wrap($cachePaths))->each(function (string $cachePath) use ($path) {
             $path = $cachePath.Str::ensureLeft($path, '/');
 
             if (File::isDirectory($path)) {
@@ -35,7 +32,7 @@ class ClearController
             }
 
             $this->deleteFile($path);
-        }
+        });
     }
 
     protected function deleteFile($path): void


### PR DESCRIPTION
Static caching for multi-site uses an array of values for the `path` config attribute. See [docs](https://statamic.dev/static-caching#multisite) for more details.

This PR adds support for both a single value (string) or array.

Without this PR, multi-site cache clearing results in a 500 server error when trying to clear the cache due to an array-to-string error:
```
Array to string conversion {"userId":".....","exception":"[object] (ErrorException(code: 0): Array to string conversion at /home/....../vendor/duncanmcclean/static-cache-manager/src/Http/Controllers/ClearController.php:24)
```