### PR TITLE
Supports Laravel 12

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         php: [8.2, 8.3, 8.4]
-        laravel: [10.*, 11.*]
+        laravel: [10.*, 11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         exclude:

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "statamic/cms": "^5.41"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.28 || ^9.6.1"
+        "orchestra/testbench": "^8.28 || ^9.6.1 || ^10.0"
     },
     "scripts": {
         "lint": [


### PR DESCRIPTION
This pull request adds Laravel 12 support to `duncanmcclean/static-cache-manager`.

Depends on:

* [ ] https://github.com/statamic/cms/pull/11433